### PR TITLE
Add request timeouts and minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ func main() {
 		return
 	}
 
+	defer generateKeyResponse.Body.Close()
+
 	body, err := io.ReadAll(generateKeyResponse.Body)
 
 	if err != nil {

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ package main
 import (
 	"fmt"
 	"github.com/ShegeHQ/datkey"
+	"io"
 )
 
 func main() {
@@ -38,7 +39,7 @@ func main() {
 		return
 	}
 
-	body, err := ioutil.ReadAll(generateKeyResponse.Body)
+	body, err := io.ReadAll(generateKeyResponse.Body)
 
 	if err != nil {
 		fmt.Println("Error reading body:", err)


### PR DESCRIPTION
- Implement 60-second timeouts for all external HTTP requests to enhance reliability.
- Minor adjustments to handle HTTP Client Reuse, error handling and logging for clarity.
- Updated documentation to io.ReadAll instead of the depreciated ioutil.ReadAll